### PR TITLE
Fork issue 28 

### DIFF
--- a/src/MotorTributarioNet/Impostos/CalulosDeBC/CalculaBaseCalculoCofins.cs
+++ b/src/MotorTributarioNet/Impostos/CalulosDeBC/CalculaBaseCalculoCofins.cs
@@ -20,6 +20,7 @@
 
 using MotorTributarioNet.Flags;
 using MotorTributarioNet.Impostos.CalulosDeBC.Base;
+using MotorTributarioNet.Impostos.Tributacoes;
 
 namespace MotorTributarioNet.Impostos.CalulosDeBC
 {
@@ -36,7 +37,12 @@ namespace MotorTributarioNet.Impostos.CalulosDeBC
 
         public decimal CalculaBaseCalculo()
         {
+            decimal valorIcms = new TributacaoIcms(_tributavel, _tipoDesconto).Calcula().Valor;
             var baseCalculo = CalculaBaseDeCalculo();
+            if (_tributavel.DeduzIcmsDaBaseDePisCofins)
+            {
+                baseCalculo -= valorIcms;
+            }
 
             return _tipoDesconto == TipoDesconto.Condincional ? CalculaIcmsComDescontoCondicional(baseCalculo) : CalculaIcmsComDescontoIncondicional(baseCalculo);
         }

--- a/src/MotorTributarioNet/Impostos/CalulosDeBC/CalculaBaseCalculoCofins.cs
+++ b/src/MotorTributarioNet/Impostos/CalulosDeBC/CalculaBaseCalculoCofins.cs
@@ -38,11 +38,8 @@ namespace MotorTributarioNet.Impostos.CalulosDeBC
         public decimal CalculaBaseCalculo()
         {
             decimal valorIcms = new TributacaoIcms(_tributavel, _tipoDesconto).Calcula().Valor;
-            var baseCalculo = CalculaBaseDeCalculo();
-            if (_tributavel.DeduzIcmsDaBaseDePisCofins)
-            {
-                baseCalculo -= valorIcms;
-            }
+            var baseCalculo = _tributavel.DeduzIcmsDaBaseDePisCofins ? CalculaBaseDeCalculo() - valorIcms : CalculaBaseDeCalculo();
+            baseCalculo = baseCalculo - baseCalculo * _tributavel.PercentualReducaoCofins / 100;
 
             return _tipoDesconto == TipoDesconto.Condincional ? CalculaIcmsComDescontoCondicional(baseCalculo) : CalculaIcmsComDescontoIncondicional(baseCalculo);
         }

--- a/src/MotorTributarioNet/Impostos/CalulosDeBC/CalculaBaseCalculoPis.cs
+++ b/src/MotorTributarioNet/Impostos/CalulosDeBC/CalculaBaseCalculoPis.cs
@@ -20,6 +20,7 @@
 
 using MotorTributarioNet.Flags;
 using MotorTributarioNet.Impostos.CalulosDeBC.Base;
+using MotorTributarioNet.Impostos.Tributacoes;
 
 namespace MotorTributarioNet.Impostos.CalulosDeBC
 {
@@ -36,7 +37,12 @@ namespace MotorTributarioNet.Impostos.CalulosDeBC
 
         public decimal CalculaBaseCalculo()
         {
+            decimal valorIcms = new TributacaoIcms(_tributavel, _tipoDesconto).Calcula().Valor;
             var baseCalculo = CalculaBaseDeCalculo();
+            if (_tributavel.DeduzIcmsDaBaseDePisCofins)
+            {
+                baseCalculo -= valorIcms;
+            }
 
             return _tipoDesconto == TipoDesconto.Condincional ? CalculaIcmsComDescontoCondicional(baseCalculo) : CalculaIcmsComDescontoIncondicional(baseCalculo);
         }

--- a/src/MotorTributarioNet/Impostos/CalulosDeBC/CalculaBaseCalculoPis.cs
+++ b/src/MotorTributarioNet/Impostos/CalulosDeBC/CalculaBaseCalculoPis.cs
@@ -38,11 +38,8 @@ namespace MotorTributarioNet.Impostos.CalulosDeBC
         public decimal CalculaBaseCalculo()
         {
             decimal valorIcms = new TributacaoIcms(_tributavel, _tipoDesconto).Calcula().Valor;
-            var baseCalculo = CalculaBaseDeCalculo();
-            if (_tributavel.DeduzIcmsDaBaseDePisCofins)
-            {
-                baseCalculo -= valorIcms;
-            }
+            var baseCalculo = _tributavel.DeduzIcmsDaBaseDePisCofins ? CalculaBaseDeCalculo() - valorIcms : CalculaBaseDeCalculo();
+            baseCalculo = baseCalculo - baseCalculo * _tributavel.PercentualReducaoPis / 100;
 
             return _tipoDesconto == TipoDesconto.Condincional ? CalculaIcmsComDescontoCondicional(baseCalculo) : CalculaIcmsComDescontoIncondicional(baseCalculo);
         }

--- a/src/MotorTributarioNet/Impostos/ITributavel.cs
+++ b/src/MotorTributarioNet/Impostos/ITributavel.cs
@@ -65,5 +65,6 @@ namespace MotorTributarioNet.Impostos
         decimal PercentualRetIrrf { get; set; }
         decimal PercentualRetInss { get; set; }
         decimal PercentualFcpSt { get; set; }
+        bool DeduzIcmsDaBaseDePisCofins { get; set; }
     }
 }

--- a/src/MotorTributarioNet/Impostos/ITributavel.cs
+++ b/src/MotorTributarioNet/Impostos/ITributavel.cs
@@ -66,5 +66,7 @@ namespace MotorTributarioNet.Impostos
         decimal PercentualRetInss { get; set; }
         decimal PercentualFcpSt { get; set; }
         bool DeduzIcmsDaBaseDePisCofins { get; set; }
+        decimal PercentualReducaoPis { get; set; }
+        decimal PercentualReducaoCofins { get; set; }
     }
 }

--- a/src/MotorTributarioNet/Impostos/Tributacoes/TributacaoCofins.cs
+++ b/src/MotorTributarioNet/Impostos/Tributacoes/TributacaoCofins.cs
@@ -45,9 +45,9 @@ namespace MotorTributarioNet.Impostos.Tributacoes
         {
             var baseCalculo = _calculaBaseCalculoCofins.CalculaBaseCalculo() + _tributavel.ValorIpi;
 
-            var valorIcms = CalculaCofins(baseCalculo);
+            var valorCofins = CalculaCofins(baseCalculo);
 
-            return new ResultadoCalculoCofins(baseCalculo, valorIcms);
+            return new ResultadoCalculoCofins(baseCalculo, valorCofins);
         }
 
         private decimal CalculaCofins(decimal baseCalculo)

--- a/src/MotorTributarioNet/Impostos/Tributacoes/TributacaoPis.cs
+++ b/src/MotorTributarioNet/Impostos/Tributacoes/TributacaoPis.cs
@@ -45,9 +45,9 @@ namespace MotorTributarioNet.Impostos.Tributacoes
         {
             var baseCalculo = _calculaBaseCalculoPis.CalculaBaseCalculo() + _tributavel.ValorIpi;
 
-            var valorIcms = CalculaPis(baseCalculo);
+            var valorPis = CalculaPis(baseCalculo);
 
-            return new ResultadoCalculoPis(baseCalculo, valorIcms);
+            return new ResultadoCalculoPis(baseCalculo, valorPis);
         }
 
         private decimal CalculaPis(decimal baseCalculo)

--- a/src/TestesUnitarios/CalculoCofinsTest.cs
+++ b/src/TestesUnitarios/CalculoCofinsTest.cs
@@ -144,7 +144,7 @@ namespace TestCalculosTributarios
             Assert.Equal(1.0032m, resultado.Valor);
         }
         [Fact]
-        public void CalculoPisSemIncidenciaICMSNaBaseDeCalculoComFreteOutrasDespesasDesconto()
+        public void CalculoCofinsSemIncidenciaICMSNaBaseDeCalculoComFreteOutrasDespesasDesconto()
         {
             var produto = new Produto()
             {
@@ -165,6 +165,24 @@ namespace TestCalculosTributarios
 
             Assert.Equal(14.8104m, resultado.BaseCalculo);
             Assert.Equal(1.1255904m, resultado.Valor);
+        }
+        [Fact]
+        public void CalculoCofinsComReducaoDeBaseDeCalculo()
+        {
+            var produto = new Produto()
+            {
+                CstPisCofins = CstPisCofins.Cst01,
+                PercentualCofins = 7.6m,
+                QuantidadeProduto = 2,
+                ValorProduto = 15.99m,
+                PercentualReducaoCofins = 30.2m,
+            };
+
+            var tributacao = new FacadeCalculadoraTributacao(produto, TipoDesconto.Incondicional);
+            var resultado = tributacao.CalculaCofins();
+
+            Assert.Equal(22.32204m, resultado.BaseCalculo);
+            Assert.Equal(1.69647504m, resultado.Valor);
         }
     }
 }

--- a/src/TestesUnitarios/CalculoCofinsTest.cs
+++ b/src/TestesUnitarios/CalculoCofinsTest.cs
@@ -122,5 +122,26 @@ namespace TestCalculosTributarios
             Assert.Equal(900.00m, resultadoCalculoCofins.BaseCalculo);
             Assert.Equal(5.85m, resultadoCalculoCofins.Valor);
         }
+
+        [Fact]
+        public void Testa_Calculo_Base_Cofins_Sem_ICMS()
+        {
+            var produto = new Produto()
+            {
+                Cst = MotorTributarioNet.Flags.Cst.Cst00,
+                CstPisCofins = CstPisCofins.Cst01,
+                PercentualCofins = 7.6m,
+                PercentualIcms = 12,
+                QuantidadeProduto = 1,
+                ValorProduto = 15m,
+                DeduzIcmsDaBaseDePisCofins = true
+            };
+
+            var tributacao = new FacadeCalculadoraTributacao(produto, TipoDesconto.Incondicional);
+            var resultado = tributacao.CalculaCofins();
+
+            Assert.Equal(13.20m, resultado.BaseCalculo);
+            Assert.Equal(1.0032m, resultado.Valor);
+        }
     }
 }

--- a/src/TestesUnitarios/CalculoCofinsTest.cs
+++ b/src/TestesUnitarios/CalculoCofinsTest.cs
@@ -124,7 +124,7 @@ namespace TestCalculosTributarios
         }
 
         [Fact]
-        public void Testa_Calculo_Base_Cofins_Sem_ICMS()
+        public void CalculoPisSemIncidenciaICMSNaBaseDeCalculo()
         {
             var produto = new Produto()
             {
@@ -142,6 +142,29 @@ namespace TestCalculosTributarios
 
             Assert.Equal(13.20m, resultado.BaseCalculo);
             Assert.Equal(1.0032m, resultado.Valor);
+        }
+        [Fact]
+        public void CalculoPisSemIncidenciaICMSNaBaseDeCalculoComFreteOutrasDespesasDesconto()
+        {
+            var produto = new Produto()
+            {
+                Cst = MotorTributarioNet.Flags.Cst.Cst00,
+                CstPisCofins = CstPisCofins.Cst01,
+                PercentualIcms = 12,
+                PercentualCofins = 7.6m,
+                QuantidadeProduto = 1,
+                ValorProduto = 15.99m,
+                Frete = 1.02m,
+                Desconto = 0.85m,
+                OutrasDespesas = 0.67m,
+                DeduzIcmsDaBaseDePisCofins = true
+            };
+
+            var tributacao = new FacadeCalculadoraTributacao(produto, TipoDesconto.Incondicional);
+            var resultado = tributacao.CalculaCofins();
+
+            Assert.Equal(14.8104m, resultado.BaseCalculo);
+            Assert.Equal(1.1255904m, resultado.Valor);
         }
     }
 }

--- a/src/TestesUnitarios/CalculoPisTest.cs
+++ b/src/TestesUnitarios/CalculoPisTest.cs
@@ -122,6 +122,26 @@ namespace TestCalculosTributarios
             Assert.Equal(900.00m, resultadoCalculoPis.BaseCalculo);
             Assert.Equal(14.85m, resultadoCalculoPis.Valor);
         }
+        [Fact]
+        public void Testa_Calculo_Base_Pis_Sem_ICMS()
+        {
+            var produto = new Produto()
+            {
+                Cst = MotorTributarioNet.Flags.Cst.Cst00,
+                CstPisCofins = CstPisCofins.Cst01,
+                PercentualIcms = 12,
+                PercentualPis = 1.65m,
+                QuantidadeProduto = 1,
+                ValorProduto = 15m,
+                DeduzIcmsDaBaseDePisCofins = true
+            };
+
+            var tributacao = new FacadeCalculadoraTributacao(produto, TipoDesconto.Incondicional);
+            var resultado = tributacao.CalculaPis();
+
+            Assert.Equal(13.20m, resultado.BaseCalculo);
+            Assert.Equal(0.2178m, resultado.Valor);
+        }
 
     }
 }

--- a/src/TestesUnitarios/CalculoPisTest.cs
+++ b/src/TestesUnitarios/CalculoPisTest.cs
@@ -123,7 +123,7 @@ namespace TestCalculosTributarios
             Assert.Equal(14.85m, resultadoCalculoPis.Valor);
         }
         [Fact]
-        public void Testa_Calculo_Base_Pis_Sem_ICMS()
+        public void CalculoPisSemIncidenciaICMSNaBaseDeCalculo()
         {
             var produto = new Produto()
             {
@@ -143,5 +143,28 @@ namespace TestCalculosTributarios
             Assert.Equal(0.2178m, resultado.Valor);
         }
 
+        [Fact]
+        public void CalculoPisSemIncidenciaICMSNaBaseDeCalculoComFreteOutrasDespesasDesconto()
+        {
+            var produto = new Produto()
+            {
+                Cst = MotorTributarioNet.Flags.Cst.Cst00,
+                CstPisCofins = CstPisCofins.Cst01,
+                PercentualIcms = 12,
+                PercentualPis = 1.65m,
+                QuantidadeProduto = 1,
+                ValorProduto = 15.99m,
+                Frete = 1.02m,
+                Desconto = 0.85m,
+                OutrasDespesas = 0.67m,
+                DeduzIcmsDaBaseDePisCofins = true
+            };
+
+            var tributacao = new FacadeCalculadoraTributacao(produto, TipoDesconto.Incondicional);
+            var resultado = tributacao.CalculaPis();
+
+            Assert.Equal(14.8104m, resultado.BaseCalculo);
+            Assert.Equal(0.2443716m, resultado.Valor);
+        }
     }
 }

--- a/src/TestesUnitarios/CalculoPisTest.cs
+++ b/src/TestesUnitarios/CalculoPisTest.cs
@@ -166,5 +166,23 @@ namespace TestCalculosTributarios
             Assert.Equal(14.8104m, resultado.BaseCalculo);
             Assert.Equal(0.2443716m, resultado.Valor);
         }
+        [Fact]
+        public void CalculoPisComReducaoDeBaseDeCalculo()
+        {
+            var produto = new Produto()
+            {
+                CstPisCofins = CstPisCofins.Cst01,
+                PercentualPis = 1.65m,
+                QuantidadeProduto = 2,
+                ValorProduto = 15.99m,
+                PercentualReducaoPis = 30.2m,
+            };
+
+            var tributacao = new FacadeCalculadoraTributacao(produto, TipoDesconto.Incondicional);
+            var resultado = tributacao.CalculaPis();
+
+            Assert.Equal(22.32204m, resultado.BaseCalculo);
+            Assert.Equal(0.36831366m, resultado.Valor);
+        }
     }
 }

--- a/src/TestesUnitarios/Entidade/Produto.cs
+++ b/src/TestesUnitarios/Entidade/Produto.cs
@@ -48,5 +48,7 @@ namespace TestCalculosTributarios.Entidade
         public decimal PercentualRetInss { get; set; }
         public decimal PercentualFcpSt { get; set; }
         public bool DeduzIcmsDaBaseDePisCofins { get; set; } = false;
+        public decimal PercentualReducaoPis { get; set; }
+        public decimal PercentualReducaoCofins { get; set; }
     }
 }

--- a/src/TestesUnitarios/Entidade/Produto.cs
+++ b/src/TestesUnitarios/Entidade/Produto.cs
@@ -47,5 +47,6 @@ namespace TestCalculosTributarios.Entidade
         public decimal PercentualRetIrrf { get; set; }
         public decimal PercentualRetInss { get; set; }
         public decimal PercentualFcpSt { get; set; }
+        public bool DeduzIcmsDaBaseDePisCofins { get; set; } = false;
     }
 }


### PR DESCRIPTION
\* (#28) Implementado nas classes CalculaBaseCalculoPis e CalculaBaseCalculoCofins a verificação para retirar o valor de ICMS da incidência da base de cálculo de Pis e Cofins.
\* (#28) Implementado cálculo de Redução de Base de Cálculo de Pis e Cofins.