### PR TITLE
Exclusão dos Testes Pis/Cofins com IPI na Base de Cálculo

### DIFF
--- a/src/TestesUnitarios/CalculoCofinsTest.cs
+++ b/src/TestesUnitarios/CalculoCofinsTest.cs
@@ -46,45 +46,6 @@ namespace TestCalculosTributarios
         }
 
         [Fact]
-        public void CalculaCofinsMaisIpi()
-        {
-            var produto = new Produto
-            {
-                PercentualCofins = 0.65m,
-                ValorProduto = 1000.00m,
-                QuantidadeProduto = 1.000m,
-                ValorIpi = 10
-            };
-
-            var facade = new FacadeCalculadoraTributacao(produto);
-
-            var resultadoCalculoCofins = facade.CalculaCofins();
-
-            Assert.Equal(1010.00m, resultadoCalculoCofins.BaseCalculo);
-            Assert.Equal(6.56m, decimal.Round(resultadoCalculoCofins.Valor, 2));
-        }
-
-        [Fact]
-        public void CalculaCofinsMaisIpiComDescontoIncondicional()
-        {
-            var produto = new Produto
-            {
-                PercentualCofins = 0.65m,
-                ValorProduto = 1000.00m,
-                QuantidadeProduto = 1.000m,
-                ValorIpi = 10,
-                Desconto = 100.00m
-            };
-
-            var facade = new FacadeCalculadoraTributacao(produto, TipoDesconto.Incondicional);
-
-            var resultadoCalculoCofins = facade.CalculaCofins();
-
-            Assert.Equal(910.00m, resultadoCalculoCofins.BaseCalculo);
-            Assert.Equal(5.92m, decimal.Round(resultadoCalculoCofins.Valor, 2));
-        }
-
-        [Fact]
         public void CalculaCofinsComIpiZero()
         {
             var produto = new Produto

--- a/src/TestesUnitarios/CalculoPisTest.cs
+++ b/src/TestesUnitarios/CalculoPisTest.cs
@@ -46,45 +46,6 @@ namespace TestCalculosTributarios
         }
 
         [Fact]
-        public void CalculoPisComIpi()
-        {
-            var produto = new Produto
-            {
-                PercentualPis = 1.65m,
-                ValorProduto = 1000.00m,
-                QuantidadeProduto = 1.000m,
-                ValorIpi = 10
-            };
-
-            var facade = new FacadeCalculadoraTributacao(produto);
-
-            var resultadoCalculoPis = facade.CalculaPis();
-
-            Assert.Equal(1010.00m, resultadoCalculoPis.BaseCalculo);
-            Assert.Equal(16.66m, decimal.Round(resultadoCalculoPis.Valor, 2));
-        }
-
-        [Fact]
-        public void CalculoPisComIpiComDescontoIncondicional()
-        {
-            var produto = new Produto
-            {
-                PercentualPis = 1.65m,
-                ValorProduto = 1000.00m,
-                QuantidadeProduto = 1.000m,
-                ValorIpi = 10,
-                Desconto = 100.00m
-            };
-
-            var facade = new FacadeCalculadoraTributacao(produto, TipoDesconto.Incondicional);
-
-            var resultadoCalculoPis = facade.CalculaPis();
-
-            Assert.Equal(910.00m, resultadoCalculoPis.BaseCalculo);
-            Assert.Equal(15.02m, decimal.Round(resultadoCalculoPis.Valor, 2));
-        }
-
-        [Fact]
         public void CalculoPisComIpiZero()
         {
             var produto = new Produto


### PR DESCRIPTION
Exclusão dos Testes Pis/Cofins com IPI na Base de Cálculo